### PR TITLE
Allow the customization of standard markdown elements

### DIFF
--- a/__tests__/fixtures/basic/pages/index.jsx
+++ b/__tests__/fixtures/basic/pages/index.jsx
@@ -6,7 +6,10 @@ import hydrate from '../../../../hydrate'
 import Test from '../components/test'
 import { paragraphCustomAlerts } from '@hashicorp/remark-plugins'
 
-const MDX_COMPONENTS = { Test }
+const MDX_COMPONENTS = {
+  Test,
+  strong: (props) => <strong className="custom-strong" {...props} />,
+}
 
 export default function TestPage({ data, mdxSource }) {
   return (

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -14,7 +14,7 @@ test('it works', () => {
 
   // server renders correctly
   expect(result).toMatch(
-    '<h1>foo</h1><span><h1>Headline</h1><p>hello <!-- -->jeff</p><button>Count: <!-- -->0</button><p>Some <strong>markdown</strong> content</p><div class="alert alert-warning g-type-body" role="alert"><p>Alert</p></div></span>'
+    '<h1>foo</h1><span><h1>Headline</h1><p>hello <!-- -->jeff</p><button>Count: <!-- -->0</button><p>Some <strong class="custom-strong">markdown</strong> content</p><div class="alert alert-warning g-type-body" role="alert"><p>Alert</p></div></span>'
   )
   // hydrates correctly
   let browser, server

--- a/hydrate.js
+++ b/hydrate.js
@@ -1,5 +1,5 @@
 const React = require('react')
-const { mdx } = require('@mdx-js/react')
+const { mdx, MDXProvider } = require('@mdx-js/react')
 
 module.exports = function hydrate({ source, renderedOutput }, components) {
   const [hydrated, setHydrated] = React.useState(false)
@@ -42,10 +42,18 @@ module.exports = function hydrate({ source, renderedOutput }, components) {
         return React.createElement(MDXContent, {});`
       )(React, ...values)
 
+      // wrapping the content with MDXProvider will allow us to customize the standard
+      // markdown components (such as "h1" or "a") with the "components" object
+      const wrappedWithMdxProvider = React.createElement(
+        MDXProvider,
+        { components },
+        hydratedFn
+      )
+
       // finally, we flip the hydrated status so this doesn't run again, and set
       // the output as the new result so that
       setHydrated(true)
-      setResult(hydratedFn)
+      setResult(wrappedWithMdxProvider)
     })
 
   return React.useMemo(() => result, [source, result])


### PR DESCRIPTION
This change allows the standard makdown elements to be customized with the `components` object

Fixes #4 