### PR TITLE
Fix hydration not happening on client-side page transition

### DIFF
--- a/idle-callback-polyfill.js
+++ b/idle-callback-polyfill.js
@@ -1,0 +1,21 @@
+if (typeof window !== 'undefined') {
+  window.requestIdleCallback =
+    window.requestIdleCallback ||
+    function (cb) {
+      var start = Date.now()
+      return setTimeout(function () {
+        cb({
+          didTimeout: false,
+          timeRemaining: function () {
+            return Math.max(0, 50 - (Date.now() - start))
+          },
+        })
+      }, 1)
+    }
+
+  window.cancelIdleCallback =
+    window.cancelIdleCallback ||
+    function (id) {
+      clearTimeout(id)
+    }
+}


### PR DESCRIPTION
Previously there was a bug where, if the `source` was updated without a full page reload, the content would not update. This resolves that bug and cleans up the code a little as well 😀

Closes #6