### PR TITLE
Improve function signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ renderToString(
       hastPlugins: []any,
       compilers: []any,
       filepath: String
-    }
+    },
+    // variable names and values which can be consumed by components
+    scope: { [key:string]: any }
   }
 )
 ```

--- a/__tests__/fixtures/basic/pages/index.jsx
+++ b/__tests__/fixtures/basic/pages/index.jsx
@@ -15,7 +15,7 @@ export default function TestPage({ data, mdxSource }) {
   return (
     <>
       <h1>{data.title}</h1>
-      {hydrate(mdxSource, MDX_COMPONENTS)}
+      {hydrate(mdxSource, { components: MDX_COMPONENTS })}
     </>
   )
 }
@@ -23,13 +23,10 @@ export default function TestPage({ data, mdxSource }) {
 export async function getStaticProps() {
   const fixturePath = path.join(process.cwd(), 'mdx/test.mdx')
   const { data, content } = matter(fs.readFileSync(fixturePath, 'utf8'))
-  const mdxSource = await renderToString(
-    content,
-    MDX_COMPONENTS,
-    {
-      remarkPlugins: [paragraphCustomAlerts],
-    },
-    data
-  )
+  const mdxSource = await renderToString(content, {
+    components: MDX_COMPONENTS,
+    mdxOptions: { remarkPlugins: [paragraphCustomAlerts] },
+    scope: data,
+  })
   return { props: { mdxSource, data } }
 }

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -55,14 +55,18 @@ test('renderToString minimal', async () => {
 
 test('renderToString with component', async () => {
   const result = await renderToString('foo <Test />', {
-    Test: () => React.createElement('span', null, 'hello world'),
+    components: {
+      Test: () => React.createElement('span', null, 'hello world'),
+    },
   })
   expect(result.renderedOutput).toEqual('<p>foo <span>hello world</span></p>')
 })
 
 test('renderToString with options', async () => {
-  const result = await renderToString('~> hello', null, {
-    remarkPlugins: [paragraphCustomAlerts],
+  const result = await renderToString('~> hello', {
+    mdxOptions: {
+      remarkPlugins: [paragraphCustomAlerts],
+    },
   })
   expect(result.renderedOutput).toEqual(
     '<div class="alert alert-warning g-type-body" role="alert"><p>hello</p></div>'
@@ -70,14 +74,12 @@ test('renderToString with options', async () => {
 })
 
 test('renderToString with scope', async () => {
-  const result = await renderToString(
-    '<Test name={bar} />',
-    { Test: ({ name }) => React.createElement('p', null, name) },
-    null,
-    {
+  const result = await renderToString('<Test name={bar} />', {
+    components: { Test: ({ name }) => React.createElement('p', null, name) },
+    scope: {
       bar: 'test',
-    }
-  )
+    },
+  })
   expect(result.renderedOutput).toEqual('<p>test</p>')
 })
 

--- a/hydrate.js
+++ b/hydrate.js
@@ -4,7 +4,7 @@ const { mdx, MDXProvider } = require('@mdx-js/react')
 const { useEffect } = require('react')
 
 module.exports = function hydrate(
-  { source, renderedOutput, scope = {} },
+  { compiledSource, renderedOutput, scope = {} },
   { components } = {}
 ) {
   // our default result is the server-rendered output
@@ -43,7 +43,7 @@ module.exports = function hydrate(
       const hydratedFn = new Function(
         'React',
         ...keys,
-        `${source}
+        `${compiledSource}
       return React.createElement(MDXContent, {});`
       )(React, ...values)
 
@@ -60,7 +60,7 @@ module.exports = function hydrate(
       setResult(wrappedWithMdxProvider)
       window.cancelIdleCallback(handle)
     })
-  }, [source])
+  }, [compiledSource])
 
   return result
 }

--- a/hydrate.js
+++ b/hydrate.js
@@ -5,7 +5,7 @@ const { useEffect } = require('react')
 
 module.exports = function hydrate(
   { source, renderedOutput, scope = {} },
-  components
+  { components } = {}
 ) {
   // our default result is the server-rendered output
   // we get this in front of users as quickly as possible

--- a/render-to-string.js
+++ b/render-to-string.js
@@ -52,7 +52,7 @@ module.exports = function renderToString(
     })
     .then((component) => {
       return {
-        source: jsSource,
+        compiledSource: jsSource,
         // react: render to string
         renderedOutput: reactRenderToString(component),
         scope,

--- a/render-to-string.js
+++ b/render-to-string.js
@@ -9,13 +9,11 @@ const React = require('react')
 
 module.exports = function renderToString(
   source,
-  components,
-  options,
-  scope = {}
+  { components, mdxOptions, scope = {} } = {}
 ) {
   let jsSource
   // transform it into react
-  return mdx(source, { ...options, skipExport: true })
+  return mdx(source, { ...mdxOptions, skipExport: true })
     .then((code) => {
       // mdx gives us back es6 code, we then need to transform into two formats:
       // - first a version we can render to string right now as a "serialized" result


### PR DESCRIPTION
As this library has developed, we have reached the point where there are too many direct arguments being passed to the function, meaning there are a few valid use cases where passing options like `renderToString(x, y null, z)` are quite normal. This is the point at which, for me, the function signature needs to be re-examined. Additionally, it was not entirely clear what arguments were required vs optional. This PR introduces a new function signature that I feel is better in every way and allows for future features to be added without pain, but it is a massively breaking change so will have to go out as a major version I think.