### PR TITLE
Wrap rendered output in <div> instead of <span>

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -17,7 +17,7 @@ test('rehydrates correctly in browser', () => {
 
   // server renders correctly
   expect(result).toMatch(
-    '<h1>foo</h1><span><h1>Headline</h1><p>hello <!-- -->jeff</p><button>Count: <!-- -->0</button><p>Some <strong class="custom-strong">markdown</strong> content</p><div class="alert alert-warning g-type-body" role="alert"><p>Alert</p></div></span>'
+    '<h1>foo</h1><div><h1>Headline</h1><p>hello <!-- -->jeff</p><button>Count: <!-- -->0</button><p>Some <strong class="custom-strong">markdown</strong> content</p><div class="alert alert-warning g-type-body" role="alert"><p>Alert</p></div></div>'
   )
   // hydrates correctly
   let browser, server

--- a/hydrate.js
+++ b/hydrate.js
@@ -10,7 +10,7 @@ module.exports = function hydrate(
   // our default result is the server-rendered output
   // we get this in front of users as quickly as possible
   const [result, setResult] = React.useState(
-    React.createElement('span', {
+    React.createElement('div', {
       dangerouslySetInnerHTML: {
         __html: renderedOutput,
       },


### PR DESCRIPTION
Block-level elements (like paragraphs) are not allowed within span elements. Wrapping the rendered output in a `<span>` could therefore result in invalid HTML (#30).

tl;dr: I was a bit afraid initially that this would break things in some cases, but in practice it’s like the whole wrapper element isn’t actually there.

## Post-change behaviour – the long version
More specifically, I manually tested several cases to see what would happen.

### MDX with multiple paragraphs
This does pretty much what you’d expect. Not much can go wrong here.

#### Input
```md
Paragraph A.

Paragraph B.
```

#### Output
```html
<div>
  <p>Paragraph A.</p>
  <p>Paragraph B.</p>
</div>
```

### MDX with a single sentence
MDX understandably converts single-sentence Markdown strings into a paragraph, so I had to find another way to determine the effect of this change on inline content.

#### Input
```md
A single sentence.
```

#### Output
```html
<div>
  <p>A single sentence.</p>
</div>
```

### Inline component
Let’s say we have a component that’s meant to be used inline:

```jsx
const Quoted = ({ children }) => (<q>{ children }</q>)
```

If I use `renderToString()` and `hydrate()` to render it on its own, it’s wrapped in a `<div>` now. Does this cause problems?

#### Input
```md
<Quoted>sigmund(): void</Quoted>
```

#### Output
```html
<div>
  <q>sigmund(): void</q>
</div>
```

### Inline component (continued)
It shouldn’t be too hard to answer that question! Let’s try to use our hydrated MDX element as an inline element:

```jsx
<main>Foo { hydratedMdx } bar</main>
```

Now the raw HTML source will look like this:

```html
<main>
  Foo
  <div>
    <q>sigmund(): void</q>
  </div>
  bar
</main>
```

But the actual tree ends up looking like this:

```html
<main>
  "Foo "
  <q>sigmund(): void</q>
  " bar"
</main>
```

No `<div>`, so it’s still inline!