### PR TITLE
Fix README for frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,7 @@ export default function TestPage({ source, frontMatter }) {
 
 export async function getStaticProps() {
   // MDX text - can be from a local file, database, anywhere
-  const source = `
----
+  const source = `---
 title: Test
 ---
 


### PR DESCRIPTION
gray-matter is not recognizing front matter because of a new line character at the end. Hence, removed the new line character in README.