### PR TITLE
fix: Typescript definition of the hydrate function

### DIFF
--- a/hydrate.d.ts
+++ b/hydrate.d.ts
@@ -10,5 +10,5 @@ export default function hydrate(
    *
    * For example: `{ ComponentName: Component }` will be accessible in the MDX as `<ComponentName/>`.
    */
-  options: { components: MdxRemote.Components }
+  options?: { components?: MdxRemote.Components }
 ): ReactNode


### PR DESCRIPTION
According to the hydrate function, the seconds parameter `options` is not required nor the property `components` inside of the `options` object.

This PR goal is to adjust the Typescript definition to represent correctly the hydrate function.

https://github.com/hashicorp/next-mdx-remote/blob/5958c0583595176ab2b44dab227270e685d77925/hydrate.js#L7-L11