### PR TITLE
Fix peer dependencies to include react 17.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
   ],
   "license": "MPL-2.0",
   "peerDependencies": {
-    "react": ">=16.13.1 <17.0.1",
-    "react-dom": ">=16.13.1 <17.0.1"
+    "react": ">=16.13.1 <=17.0.1",
+    "react-dom": ">=16.13.1 <=17.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Having upgraded react to 17.0.1 on my next js blog seems to be working with next-mdx-remote.

It is for example used on this blog.

https://nextjs.marcofranssen.nl/blog/building-a-elasticsearch-cluster-using-docker-compose-and-traefik 

This PR includes react 17.0.1 as a peer dependency to remove the npm warning.