### PR TITLE
Support web components

### DIFF
--- a/hydrate.js
+++ b/hydrate.js
@@ -38,7 +38,7 @@ module.exports = function hydrate(params, options) {
       var handle = window.requestIdleCallback(function () {
         // first we set up the scope which has to include the mdx custom
         // create element function as well as any components we're using
-        var fullScope = Object.assign({ mdx: MDX.mdx }, components, scope)
+        var fullScope = Object.assign({ mdx: MDX.mdx }, scope)
         var keys = Object.keys(fullScope)
         var values = Object.values(fullScope)
 


### PR DESCRIPTION
I'm converting a site using web components to Next.js using this plugin, but attempting to customize how they're rendered causes `hydrate` to fail:

```js
const components = {
  'my-code': props => {
    return <code {...props} />
  }
}
```

> ![Screen Shot 2021-01-15 at 1 57 12 PM](https://user-images.githubusercontent.com/15182/104780916-65a38d80-5736-11eb-925b-6bde2c7b8675.png)

The reason being `my-code` isn't a valid variable name that's passed into the eval'd function scope.

All it required was removing `components` from the `fullScope`.

An alternative to this would be to `.filter` components to ignore anything with a `-`.