### PR TITLE
fix: relative type imports so they work when consumed

### DIFF
--- a/hydrate.d.ts
+++ b/hydrate.d.ts
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-import { MdxRemote } from 'types'
+import { MdxRemote } from './types'
 
 export default function hydrate(
   /** Rendered MDX output. The direct output of `renderToString`. */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-import hydrate from 'hydrate'
-import renderToString from 'render-to-string'
+import hydrate from './hydrate'
+import renderToString from './render-to-string'
 
 declare module 'next-mdx-remote/render-to-string' {
   export default renderToString

--- a/render-to-string.d.ts
+++ b/render-to-string.d.ts
@@ -1,5 +1,5 @@
-import { MdxRemote } from 'types'
 import { Pluggable, Compiler } from 'unified'
+import { MdxRemote } from './types'
 
 /**
  * Runs the MDX renderer on the MDX string provided with the components and data provided.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "jsx": "preserve",
-    "baseUrl": ".",
     "typeRoots": ["node_modules/@types", "./"]
   },
   "exclude": ["__tests__"]


### PR DESCRIPTION
I noticed that the return types weren't showing up as expected when consuming the types, and I believe it is because of the non-relative imports being used here. They worked in the source because of our `baseUrl: "."` setting, but not during consumption.