### PR TITLE
Add example of replacing HTML tags as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,27 @@ export async function getStaticProps() {
 
 That's it! The provider will be wrapped around your MDX page when hydrated and you will be able to access any of its values from within your components. For an example using a custom provider, check out the test suite.
 
+### Replacing main components
+
+Hydratation will use [`MDXProvider`](https://mdxjs.com/getting-started#mdxprovider) under the hood. This means you can replace HTML tags by custom components during hydratation. Those components are listed in MDXJS [Table of components](https://mdxjs.com/table-of-components). 
+
+An example use case is rendering the content with your preferred styling library.
+
+```jsx
+import { Typography } from "@material-ui/core";
+const components = { Test }
+
+export default function TestPage({ source }) {
+  const content = hydrate(source, { components: h2: (props) => <Typography variant="h2" {...props} /> });
+  return <div className="wrapper">{content}</div>
+}
+```
+
+Note: you need to add components for HTML tags **only during hydratation**, not during server-side `renderToString` call, contrary to custom components like `<Test />`.
+
+Note: "th/td" won't work because of the "/" in the component name.
+
+
 ### How Can I Build A Blog With This?
 
 Data has shown that 99% of use cases for all developer tooling are building unnecessarily complex personal blogs. Just kidding. But seriously, if you are trying to build a blog for personal or small business use, consider just using normal html and css. You definitely do not need to be using a heavy full-stack javascript framework to make a simple blog. You'll thank yourself later when you return to make an update in a couple years and there haven't been 10 breaking releases to all of your dependencies.

--- a/README.md
+++ b/README.md
@@ -202,21 +202,16 @@ That's it! The provider will be wrapped around your MDX page when hydrated and y
 
 ### Replacing main components
 
-Hydratation will use [`MDXProvider`](https://mdxjs.com/getting-started#mdxprovider) under the hood. This means you can replace HTML tags by custom components during hydratation. Those components are listed in MDXJS [Table of components](https://mdxjs.com/table-of-components). 
+Rendering will use [`MDXProvider`](https://mdxjs.com/getting-started#mdxprovider) under the hood. This means you can replace HTML tags by custom components. Those components are listed in MDXJS [Table of components](https://mdxjs.com/table-of-components). 
 
 An example use case is rendering the content with your preferred styling library.
 
 ```jsx
 import { Typography } from "@material-ui/core";
-const components = { Test }
 
-export default function TestPage({ source }) {
-  const content = hydrate(source, { components: h2: (props) => <Typography variant="h2" {...props} /> });
-  return <div className="wrapper">{content}</div>
-}
+const components = { Test, h2: (props) => <Typography variant="h2" {...props} /> }
+...
 ```
-
-Note: you need to add components for HTML tags **only during hydratation**, not during server-side `renderToString` call, contrary to custom components like `<Test />`.
 
 Note: "th/td" won't work because of the "/" in the component name.
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ export async function getStaticProps() {
 
 That's it! The provider will be wrapped around your MDX page when hydrated and you will be able to access any of its values from within your components. For an example using a custom provider, check out the test suite.
 
-### Replacing main components
+### Replacing default components
 
 Rendering will use [`MDXProvider`](https://mdxjs.com/getting-started#mdxprovider) under the hood. This means you can replace HTML tags by custom components. Those components are listed in MDXJS [Table of components](https://mdxjs.com/table-of-components). 
 


### PR DESCRIPTION
MDXProvider not only let you inject custom components but also customize the rendering of the main components, like titles and stuff.
This is needed if you want to use material UI for instance.

This means during hydratation, you need to inject your components.

~~Something I don't get: why do you need to add `components` twice, during render to string and during hydratation , for custom MDX components like `<Test />`? This is not the case for HTML tags like "h1".~~

Yeah actually you need it during string render as well for SSR, makes sense.

One small difference also, the key `"th/td"` gave a syntax error, while it is normally valid: "SyntaxError: Arg string terminates parameters early"