### PR TITLE
Add option to hydrate synchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ This library exposes two functions, `renderToString` and `hydrate`, much like `r
 
   Visit <https://github.com/mdx-js/mdx/blob/master/packages/mdx/index.js> for available `mdxOptions`.
 
-- **`hydrate(source: object, { components?: object, provider?: object })`**
+- **`hydrate(source: object, { components?: object, provider?: object, synchronous?: boolean })`**
 
-  **`hydrate`** consumes the output of `renderToString` as well as the same components argument as `renderToString`. Its result can be rendered directly into your component. This function will initially render static content, and hydrate it when the browser isn't busy with higher priority tasks.
+  **`hydrate`** consumes the output of `renderToString` as well as the same components argument as `renderToString`. Its result can be rendered directly into your component. This function will initially render static content, and hydrate it when the browser isn't busy with higher priority tasks. If the option `synchronous: true` is given, it will instead render content synchronously (skipping the static content altogether), which gives a slower initial render but avoids the default behavior of replacing the contents of the DOM after the asynchronous hydration is complete.
 
   ```ts
   hydrate(
@@ -118,6 +118,7 @@ This library exposes two functions, `renderToString` and `hydrate`, much like `r
     {
       components: { name: React.ComponentType },
       provider: { component: React.ComponentType, props: Record<string, unknown> },
+      synchronous: boolean,
     }
   )
   ```

--- a/hydrate.d.ts
+++ b/hydrate.d.ts
@@ -18,5 +18,9 @@ export default function hydrate(
      * For example: `{ provider: FooProvider, props: { foo: 'bar' } }`
      */
     provider?: MdxRemote.Provider
+    /**
+     * Whether to hydrate synchronously.
+     */
+    synchronous?: boolean
   }
 ): ReactNode


### PR DESCRIPTION
The original behavior to hydrate asynchronously causes the DOM subtree corresponding to the MDX output to be entirely replaced by React reconciliation once async hydration is complete (which switches from a div with dangerouslySetInnerHTML to an MDXProvider component). This works okay when the Markdown contains only simple elements like paragraphs with text, but it's jarring in other settings, e.g. when there are videos in the document.

This patch adds an option to render synchronously, so there's no switch-over from the div to the MDXProvider, so there's no extraneous DOM updates that happen.

Fixes #118.

---

This patch doesn't include a test for this new behavior. I am not familiar with the tools used in the testing setup in this project, so I figured it would be easier for someone else to add the tests.

Some things that may be worth discussing:

- What should this option be called? Is `synchronous: true` a reasonable name?
- Can we change the default behavior, as suggested by @peduarte in #118? I agree with the reasoning given in https://github.com/hashicorp/next-mdx-remote/issues/118#issuecomment-824138959, but in some sense changing the default to synchronous could be seen as a breaking change (based on the README, it seems like the spec guaranteed the async behavior by default).