### PR TITLE
fix: usage of fragments in MDX

### DIFF
--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -190,6 +190,18 @@ export const foo = 'bar'`)
 
     expect(resultA).not.toEqual(resultB)
   })
+
+  test('fragments', async () => {
+    const components = {
+      Test: ({ content }) => content,
+    }
+
+    const result = await renderStatic(
+      `<Test content={<>Rendering a fragment</>} />`,
+      { components }
+    )
+    expect(result).toMatchInlineSnapshot(`"Rendering a fragment"`)
+  })
 })
 
 afterAll(async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,7 +68,7 @@ export function MDXRemote({
     // if we're ready to render, we can assemble the component tree and let React do its thing
     // first we set up the scope which has to include the mdx custom
     // create element function as well as any components we're using
-    const fullScope = Object.assign({ mdx: MDX.mdx }, scope)
+    const fullScope = Object.assign({ mdx: MDX.mdx, React }, scope)
     const keys = Object.keys(fullScope)
     const values = Object.values(fullScope)
 


### PR DESCRIPTION
closes #127 

v3 accidentally broke usage of fragments, as React is no longer in scope. This adds a test case and once again passes React into `scope` when the compiled MDX source is rendered.