### PR TITLE
fix(serialize): make esbuild resolution more reliable

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -16,7 +16,7 @@ import { MDXRemoteSerializeResult, SerializeOptions } from './types'
 const requireResolve =
   // @ts-expect-error -- check if we're in a webpack context
   typeof __non_webpack_require__ === 'function'
-    ? // @ts-expect-error -- check if we're in a webpack context
+    ? // @ts-expect-error -- __non_webpack_require__ === require at this point
       __non_webpack_require__.resolve
     : require.resolve
 


### PR DESCRIPTION
Rely on node's native `require.resolve` method to determine where its binary lives.

fixes #134 