### PR TITLE
Delete TOC; add link to Migration notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,6 @@ A set of light utilities allowing mdx to be loaded within `getStaticProps` or `g
 
 ---
 
-- [Installation](#installation)
-- [Examples](#examples)
-- [APIs](#apis)
-- [Frontmatter & Custom Processing](#frontmatter--custom-processing)
-- [Background & Theory](#background--theory)
-- [Caveats](#caveats)
-- [Security](#security)
-- [TypeScript](#typescript)
-- [License](#license)
-
----
-
 ## Installation
 
 ```sh
@@ -426,6 +414,10 @@ export const getStaticProps: GetStaticProps<MDXRemoteSerializeResult> = async ()
   return { props: { mdxSource } }
 }
 ```
+
+## Migrating from v2 to v3
+
+See https://github.com/hashicorp/next-mdx-remote/releases/tag/3.0.0
 
 ## License
 


### PR DESCRIPTION
# Description

This deletes the table of contents at the top of the readme.
- Github recently built a TOC into their UI
  - ![image](https://user-images.githubusercontent.com/26389321/124186520-6c2a8500-da8a-11eb-8b10-277950833dbb.png)

- This is one less _thing_ that needs to be maintained

This adds a section + link to the V3 breaking chanes
- This took me a while to discover, and I also discovered by chance when I wanted to upgrade from V2 to V3.