### PR TITLE
Match requestIdleCallback definition with lib.dom

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,9 +4,9 @@ import * as MDX from '@mdx-js/react'
 import { MDXRemoteSerializeResult } from './types'
 
 // requestIdleCallback types found here: https://github.com/microsoft/TypeScript/issues/21309
-type RequestIdleCallbackHandle = any
+type RequestIdleCallbackHandle = number
 type RequestIdleCallbackOptions = {
-  timeout: number
+  timeout?: number
 }
 type RequestIdleCallbackDeadline = {
   readonly didTimeout: boolean


### PR DESCRIPTION
Somewhere in Typescript v4.4.x, requestIdleCallback definitions were added to lib.dom.d.ts. This commit aligns this repo's
version of them with the official versions. https://github.com/microsoft/TypeScript/blob/v4.4.2/lib/lib.dom.d.ts#L17326