### PR TITLE
Don't modify the options passed in

### DIFF
--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -90,14 +90,16 @@ describe('serialize', () => {
   })
 
   test('with options', async () => {
-    const result = await renderStatic('~> hello', {
+    const options = {
       mdxOptions: {
         remarkPlugins: [paragraphCustomAlerts],
       },
-    })
+    }
+    const result = await renderStatic('~> hello', options)
     expect(result).toMatchInlineSnapshot(
       `"<div class=\\"alert alert-warning g-type-body\\" role=\\"alert\\"><p>hello</p></div>"`
     )
+    expect(options.mdxOptions.remarkPlugins.length).toBe(1)
   })
 
   test('with scope', async () => {
@@ -182,7 +184,7 @@ export const foo = 'bar'`)
     const mdx = `import foo from 'bar'
 
     foo **bar**
-    
+
     export const foo = 'bar'`
 
     const resultA = await serialize(mdx, { target: 'esnext' })

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -63,10 +63,16 @@ export async function serialize(
     target = ['es2020', 'node12'],
   }: SerializeOptions = {}
 ): Promise<MDXRemoteSerializeResult> {
-  mdxOptions.remarkPlugins = [
+  // don't modify the original object when adding our own plugin
+  // this allows code to reuse the same options object
+  const remarkPlugins = [
     ...(mdxOptions.remarkPlugins || []),
     removeImportsExportsPlugin,
   ]
+  mdxOptions = {
+    ...mdxOptions,
+    remarkPlugins,
+  }
 
   const compiledMdx = await mdx(source, { ...mdxOptions, skipExport: true })
   const transformResult = await transform(compiledMdx, {


### PR DESCRIPTION
If you create a single options object and pass that to multiple invocations of `serialize`, you'll notice that the `remarkPlugins` array will grow by 1 during each invocation. This is because we're modifying shared data.

We're making a copy of `remarkPlugins`, but we're dealing with a reference to the same `mdxOptions` object

eg:

```
const options = { mdxOptions: remarkPlugins: [] };

await serialize(foo, options);
// options.mdxOptions.remarkPlugins.length === 1
await serialize(foo, options);
// options.mdxOptions.remarkPlugins.length === 2
```

Impact:

`serialize()` slows down after each subsequent invocation if being passed the same options object (which is perfectly reasonable to do)