### PR TITLE
Fixed Type Error in Typescript Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ export default function ExamplePage({ mdxSource }: Props) {
   )
 }
 
-export const getStaticProps: GetStaticProps<MDXRemoteSerializeResult> = async () => {
+export const getStaticProps: GetStaticProps<{mdxSource: MDXRemoteSerializeResult}> = async () => {
   const mdxSource = await serialize('some *mdx* content: <ExampleComponent />')
   return { props: { mdxSource } }
 }


### PR DESCRIPTION
getStaticProps would error out with: Property 'compiledSource' is missing in type '{ mdxSource: MDXRemoteSerializeResult<Record<string, unknown>>; componentNames: (string | null)[]; }' but required in type 'MDXRemoteSerializeResult<Record<string, unknown>>'.