### PR TITLE
Pass through properties to top-level MDX component

### DIFF
--- a/.jest/utils.tsx
+++ b/.jest/utils.tsx
@@ -11,13 +11,11 @@ export async function renderStatic(
     components,
     scope,
     mdxOptions,
-    minifyOptions,
     parseFrontmatter,
   }: SerializeOptions & Pick<MDXRemoteProps, 'components'> = {}
 ): Promise<string> {
   const mdxSource = await serialize(mdx, {
     mdxOptions,
-    minifyOptions,
     parseFrontmatter,
   })
 

--- a/__tests__/serialize.test.tsx
+++ b/__tests__/serialize.test.tsx
@@ -47,6 +47,18 @@ describe('serialize', () => {
     expect(result).toMatchInlineSnapshot(`"<p>test</p>"`)
   })
 
+  test('with scope props', async () => {
+    const result = await renderStatic('<p>{props.baz}</p>', {
+      scope: {
+        bar: 'test',
+        props: {
+          baz: 'test2',
+        },
+      },
+    })
+    expect(result).toMatchInlineSnapshot(`"<p>test2</p>"`)
+  })
+
   test('with custom provider', async () => {
     const TestContext = React.createContext(null)
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ declare global {
 
 export type MDXRemoteProps = MDXRemoteSerializeResult & {
   /**
-   * A object mapping names to React components.
+   * An object mapping names to React components.
    * The key used will be the name accessible to MDX.
    *
    * For example: `{ ComponentName: Component }` will be accessible in the MDX as `<ComponentName/>`.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,7 +46,7 @@ export { MDXRemoteSerializeResult }
 export function MDXRemote({
   compiledSource,
   frontmatter,
-  scope,
+  scope: scopeWithProps,
   components = {},
   lazy,
 }: MDXRemoteProps) {
@@ -67,6 +67,8 @@ export function MDXRemote({
   }, [])
 
   const Content: React.ElementType = useMemo(() => {
+    const { props = {}, ...scope } = scopeWithProps || {}
+
     // if we're ready to render, we can assemble the component tree and let React do its thing
     // first we set up the scope which has to include the mdx custom
     // create element function as well as any components we're using
@@ -88,8 +90,10 @@ export function MDXRemote({
       keys.concat(`${compiledSource}`)
     )
 
-    return hydrateFn.apply(hydrateFn, values).default
-  }, [scope, compiledSource])
+    const Component = hydrateFn.apply(hydrateFn, values).default
+
+    return () => <Component {...props} />
+  }, [scopeWithProps, compiledSource])
 
   if (!isReadyToRender) {
     // If we're not ready to render, return an empty div to preserve SSR'd markup


### PR DESCRIPTION
Closes #183 by fixing the `props` shadowing issue in `scope`. As was, `props` inside the `mdx` scope was being overridden by the implicit empty props passed to the top-level component for the rendered MDX. This extracts `props` from `scope` and overrides the props used on construction by wrapping the top-level component.