### PR TITLE
Fix TFrontmatter type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export interface SerializeOptions {
  */
 export type MDXRemoteSerializeResult<
   TScope = Record<string, unknown>,
-  TFrontmatter = Record<string, string>
+  TFrontmatter = Record<string, any>
 > = {
   /**
    * The compiledSource, generated from next-mdx-remote/serialize


### PR DESCRIPTION
The type of `TFrontmatter = Record<string, string>` is incorrect, I understand it was supposed to be customisable and that most keys will *probably* be a string, though there is the possibility of it being an object/list/string so replacing the value type with `any` is correct.

Closes #302