### PR TITLE
Support serializing all VFile-compatible values

### DIFF
--- a/.jest/utils.tsx
+++ b/.jest/utils.tsx
@@ -4,9 +4,10 @@ import React from 'react'
 import { MDXRemote, MDXRemoteProps } from '../src/index'
 import { serialize } from '../src/serialize'
 import { SerializeOptions } from '../src/types'
+import { VFileCompatible } from 'vfile'
 
 export async function renderStatic(
-  mdx: string,
+  mdx: VFileCompatible,
   {
     components,
     scope,

--- a/__tests__/serialize.test.tsx
+++ b/__tests__/serialize.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import ReactDOMServer from 'react-dom/server'
 import { paragraphCustomAlerts } from '@hashicorp/remark-plugins'
 import * as MDX from '@mdx-js/react'
+import { VFile } from 'vfile'
 
 import { MDXRemote } from '../src/index'
 import { serialize } from '../src/serialize'
@@ -162,5 +163,15 @@ hello: world
         More information: https://mdxjs.com/docs/troubleshooting-mdx]
       `)
     }
+  })
+
+  test('supports VFile', async () => {
+    const result = await renderStatic(new VFile('foo **bar**'))
+    expect(result).toMatchInlineSnapshot(`"<p>foo <strong>bar</strong></p>"`)
+  })
+
+  test('supports Buffer', async () => {
+    const result = await renderStatic(Buffer.from('foo **bar**'))
+    expect(result).toMatchInlineSnapshot(`"<p>foo <strong>bar</strong></p>"`)
   })
 })

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -32,7 +32,6 @@ function getCompileOptions(
  * Parses and compiles the provided MDX string. Returns a result which can be passed into <MDXRemote /> to be rendered.
  */
 export async function serialize(
-  /** Raw MDX contents as a string. */
   source: VFileCompatible,
   {
     scope = {},

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,5 +1,5 @@
 import { compile, CompileOptions } from '@mdx-js/mdx'
-import { VFile } from 'vfile'
+import { VFile, VFileCompatible } from 'vfile'
 import { matter } from 'vfile-matter'
 
 import { createFormattedMDXError } from './format-mdx-error'
@@ -33,14 +33,14 @@ function getCompileOptions(
  */
 export async function serialize(
   /** Raw MDX contents as a string. */
-  source: string,
+  source: VFileCompatible,
   {
     scope = {},
     mdxOptions = {},
     parseFrontmatter = false,
   }: SerializeOptions = {}
 ): Promise<MDXRemoteSerializeResult> {
-  const vfile = new VFile({ value: source })
+  const vfile = new VFile(source)
 
   // makes frontmatter available via vfile.data.matter
   if (parseFrontmatter) {


### PR DESCRIPTION
This PR adds support for serializing arbitrary VFile-compatible values, not just strings. This takes advantage of the fact that the `VFile` constructor supports a string, Buffer, or an existing `VFile` object ([source](https://github.com/vfile/vfile/blob/5181b5d0be113a6cb698be123d1226aadcac720c/lib/index.js#L61-L77)).

Closes #309.