### PR TITLE
Allow react 18 as peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
   ],
   "license": "MPL-2.0",
   "peerDependencies": {
-    "react": ">=16.x <=18.x",
-    "react-dom": ">=16.x <=18.x"
+    "react": ">=16.x <=19.x",
+    "react-dom": ">=16.x <=19.x"
   },
   "engines": {
     "node": ">=14",


### PR DESCRIPTION
This has been tested and is working with react 18, so we should make sure this is indicated in our peer deps!