### PR TITLE
Fix: export `jsx-dev-runtime` in development mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "4.2.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@mdx-js/mdx": "^2.0.0",
-        "@mdx-js/react": "^2.0.0",
+        "@mdx-js/mdx": "^2.2.1",
+        "@mdx-js/react": "^2.2.1",
         "vfile": "^5.3.0",
         "vfile-matter": "^3.0.1"
       },
@@ -2050,15 +2050,15 @@
       }
     },
     "node_modules/@mdx-js/mdx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.0.0.tgz",
-      "integrity": "sha512-Q/Zv+gdm80qcxpmL/Dtd/b9+UyZjjJUCQeZyywLAQqre648hRYgeGNPu7Bl2hB7M8/WBLXpabQEKW3dmGdDTDQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.2.1.tgz",
+      "integrity": "sha512-hZ3ex7exYLJn6FfReq8yTvA6TE53uW9UHJQM9IlSauOuS55J9y8RtA7W+dzp6Yrzr00/U1sd7q+Wf61q6SfiTQ==",
       "dependencies": {
-        "@types/estree-jsx": "^0.0.1",
+        "@types/estree-jsx": "^1.0.0",
         "@types/mdx": "^2.0.0",
-        "astring": "^1.6.0",
         "estree-util-build-jsx": "^2.0.0",
         "estree-util-is-identifier-name": "^2.0.0",
+        "estree-util-to-js": "^1.1.0",
         "estree-walker": "^3.0.0",
         "hast-util-to-estree": "^2.0.0",
         "markdown-extensions": "^1.0.0",
@@ -2075,6 +2075,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@mdx-js/mdx/node_modules/@types/estree-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
+      "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/@mdx-js/mdx/node_modules/estree-walker": {
@@ -2119,9 +2127,9 @@
       }
     },
     "node_modules/@mdx-js/react": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.0.0.tgz",
-      "integrity": "sha512-icpMd43xqORnHSVRwALZv3ELN3IS7VS3BL+FyH2FFergQPSQ21FX0lN+OMIs0X+3dGY1L0DLhBCkMfPO+yDG7Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.2.1.tgz",
+      "integrity": "sha512-YdXcMcEnqZhzql98RNrqYo9cEhTTesBiCclEtoiQUbJwx87q9453GTapYU6kJ8ZZ2ek1Vp25SiAXEFy5O/eAPw==",
       "dependencies": {
         "@types/mdx": "^2.0.0",
         "@types/react": ">=16"
@@ -3100,9 +3108,9 @@
       }
     },
     "node_modules/astring": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.7.5.tgz",
-      "integrity": "sha512-lobf6RWXb8c4uZ7Mdq0U12efYmpD1UFnyOWVJPTa3ukqZrMopav+2hdNu0hgBF0JIBFK9QgrBDfwYvh3DFJDAA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.4.tgz",
+      "integrity": "sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw==",
       "bin": {
         "astring": "bin/astring"
       }
@@ -4966,6 +4974,36 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-1.1.0.tgz",
+      "integrity": "sha512-490lbfCcpLk+ofK6HCgqDfYs4KAfq6QVvDw3+Bm1YoKRgiOjKiKYGAVQE1uwh7zVxBgWhqp4FDtp5SqunpUk1A==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js/node_modules/@types/estree-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
+      "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/estree-util-to-js/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/estree-util-visit": {
@@ -16869,15 +16907,15 @@
       }
     },
     "@mdx-js/mdx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.0.0.tgz",
-      "integrity": "sha512-Q/Zv+gdm80qcxpmL/Dtd/b9+UyZjjJUCQeZyywLAQqre648hRYgeGNPu7Bl2hB7M8/WBLXpabQEKW3dmGdDTDQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.2.1.tgz",
+      "integrity": "sha512-hZ3ex7exYLJn6FfReq8yTvA6TE53uW9UHJQM9IlSauOuS55J9y8RtA7W+dzp6Yrzr00/U1sd7q+Wf61q6SfiTQ==",
       "requires": {
-        "@types/estree-jsx": "^0.0.1",
+        "@types/estree-jsx": "^1.0.0",
         "@types/mdx": "^2.0.0",
-        "astring": "^1.6.0",
         "estree-util-build-jsx": "^2.0.0",
         "estree-util-is-identifier-name": "^2.0.0",
+        "estree-util-to-js": "^1.1.0",
         "estree-walker": "^3.0.0",
         "hast-util-to-estree": "^2.0.0",
         "markdown-extensions": "^1.0.0",
@@ -16892,6 +16930,14 @@
         "vfile": "^5.0.0"
       },
       "dependencies": {
+        "@types/estree-jsx": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
+          "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
+          "requires": {
+            "@types/estree": "*"
+          }
+        },
         "estree-walker": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.0.tgz",
@@ -16924,9 +16970,9 @@
       }
     },
     "@mdx-js/react": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.0.0.tgz",
-      "integrity": "sha512-icpMd43xqORnHSVRwALZv3ELN3IS7VS3BL+FyH2FFergQPSQ21FX0lN+OMIs0X+3dGY1L0DLhBCkMfPO+yDG7Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.2.1.tgz",
+      "integrity": "sha512-YdXcMcEnqZhzql98RNrqYo9cEhTTesBiCclEtoiQUbJwx87q9453GTapYU6kJ8ZZ2ek1Vp25SiAXEFy5O/eAPw==",
       "requires": {
         "@types/mdx": "^2.0.0",
         "@types/react": ">=16"
@@ -17678,9 +17724,9 @@
       "dev": true
     },
     "astring": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.7.5.tgz",
-      "integrity": "sha512-lobf6RWXb8c4uZ7Mdq0U12efYmpD1UFnyOWVJPTa3ukqZrMopav+2hdNu0hgBF0JIBFK9QgrBDfwYvh3DFJDAA=="
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.4.tgz",
+      "integrity": "sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw=="
     },
     "async-retry": {
       "version": "1.2.1",
@@ -19142,6 +19188,31 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-2.0.0.tgz",
       "integrity": "sha512-aXXZFVMnBBDRP81vS4YtAYJ0hUkgEsXea7lNKWCOeaAquGb1Jm2rcONPB5fpzwgbNxulTvrWuKnp9UElUGAKeQ=="
+    },
+    "estree-util-to-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-1.1.0.tgz",
+      "integrity": "sha512-490lbfCcpLk+ofK6HCgqDfYs4KAfq6QVvDw3+Bm1YoKRgiOjKiKYGAVQE1uwh7zVxBgWhqp4FDtp5SqunpUk1A==",
+      "requires": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "dependencies": {
+        "@types/estree-jsx": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
+          "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
+          "requires": {
+            "@types/estree": "*"
+          }
+        },
+        "source-map": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
+        }
+      }
     },
     "estree-util-visit": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "./serialize": "./serialize.js"
   },
   "dependencies": {
-    "@mdx-js/mdx": "^2.0.0",
-    "@mdx-js/react": "^2.0.0",
+    "@mdx-js/mdx": "^2.2.1",
+    "@mdx-js/react": "^2.2.1",
     "vfile": "^5.3.0",
     "vfile-matter": "^3.0.1"
   },

--- a/src/jsx-runtime.cjs
+++ b/src/jsx-runtime.cjs
@@ -3,6 +3,8 @@
  *
  * Inspired by the approach here: https://github.com/contentlayerdev/contentlayer/blob/main/packages/next-contentlayer/src/hooks/jsx-runtime.cjs
  */
-const jsxRuntime = require('react/jsx-runtime')
-
-module.exports.jsxRuntime = jsxRuntime
+if (process.env.NODE_ENV === 'development') {
+  module.exports.jsxRuntime = require('react/jsx-dev-runtime')
+} else {
+  module.exports.jsxRuntime = require('react/jsx-runtime')
+}


### PR DESCRIPTION
From `@mdx-js/mdx` version 2.2.0 onwards, the compiled source uses `jdxDEV` from `react/jsx-dev-runtime` in development mode rather than `jdx-runtime`. This patch determines whether we should export `jsx-dev-runtime` by checking `process.env.NODE_ENV`. This environment variable should be always present in Next.js in both browser and server environment. `@mdx-js/*` are bumped to `^2.2.1` because this change is incompatible with version 2.1.5 or older.

Fixes `TypeError: _jsxDEV is not a function` error https://github.com/hashicorp/next-mdx-remote/issues/307#issuecomment-1352299456