### PR TITLE
Pass components directly to compiled MDX function

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,9 +101,7 @@ export function MDXRemote({
   // wrapping the content with MDXProvider will allow us to customize the standard
   // markdown components (such as "h1" or "a") with the "components" object
   const content = (
-    <mdx.MDXProvider components={components}>
-      <Content />
-    </mdx.MDXProvider>
+    <Content components={components} />
   )
 
   // If lazy = true, we need to render a wrapping div to preserve the same markup structure that was SSR'd


### PR DESCRIPTION
This will make it easier to add support for React Server Components in a follow-up PR.

MDX already takes a `components` prop so the additional context provider is not needed.