### PR TITLE
fix(rsc): do not require compiledSource in types

### DIFF
--- a/__tests__/integration.test.tsx
+++ b/__tests__/integration.test.tsx
@@ -133,7 +133,7 @@ createDescribe(
     })
 
     test.each(['/app-dir-mdx/mdxremote', '/app-dir-mdx/compile-mdx'])(
-      'development - RSC - %s',
+      '%s',
       async (path) => {
         const page = await browser().newPage()
         page.on('console', (msg) => console.log(msg.text()))

--- a/src/rsc.tsx
+++ b/src/rsc.tsx
@@ -10,7 +10,10 @@ import { VFileCompatible } from 'vfile'
 import { MDXProvider } from '@mdx-js/react'
 import { serialize } from './serialize'
 
-export type MDXRemoteProps = MDXRemoteSerializeResult & {
+export type MDXRemoteProps = Omit<
+  MDXRemoteSerializeResult,
+  'compiledSource'
+> & {
   source: VFileCompatible
   options?: SerializeOptions
   /**


### PR DESCRIPTION
Update types in our RSC APIs to not required `compiledSource`, as everything is handled internally.

fixes #336 