### PR TITLE
fix: TFrontmatter type to unknown

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface SerializeOptions {
  */
 export type MDXRemoteSerializeResult<
   TScope = Record<string, unknown>,
-  TFrontmatter = Record<string, string>
+  TFrontmatter = Record<string, unknown>
 > = {
   /**
    * The compiledSource, generated from next-mdx-remote/serialize


### PR DESCRIPTION
As per this discussion, TFrontmatter should be much more flexible than accepting a string. Correcting this to unknown.  https://github.com/hashicorp/next-mdx-remote/pull/306#issuecomment-1298063281