### PR TITLE
feat: Improve frontmatter types, pass generic TFrontmatter type through

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,25 +524,26 @@ export default function Home() {
 
 ```tsx
 // app/page.js
-import { compileMDX } from "next-mdx-remote/rsc";
+import { compileMDX } from 'next-mdx-remote/rsc'
 
 export default async function Home() {
-  const {content, frontmatter} = compileMDX({
-     source: `
+  // Optionally provide a type for your frontmatter object
+  const { content, frontmatter } = compileMDX<{ title: string }>({
+    source: `
       ---
       title: RSC Frontmatter Example
       ---
       # Hello World
       This is from Server Components!
     `,
-    options: { parseFrontmatter: true }
+    options: { parseFrontmatter: true },
   })
   return (
     <>
       <h1>{frontmatter.title}</h1>
       {content}
-   </>
-  );
+    </>
+  )
 }
 ```
 

--- a/__tests__/rsc.test.tsx
+++ b/__tests__/rsc.test.tsx
@@ -13,9 +13,9 @@ title: 'Hello World'
       },
     })
 
-    expect(frontmatter?.title).toEqual('Hello World')
+    expect(frontmatter.title).toEqual('Hello World')
 
     // @ts-expect-error -- blah does not exist on the frontmatter type
-    expect(frontmatter?.blah).toBeUndefined()
+    expect(frontmatter.blah).toBeUndefined()
   })
 })

--- a/__tests__/rsc.test.tsx
+++ b/__tests__/rsc.test.tsx
@@ -8,6 +8,9 @@ title: 'Hello World'
 ---
 
 # Hi`,
+      options: {
+        parseFrontmatter: true,
+      },
     })
 
     expect(frontmatter?.title).toEqual('Hello World')

--- a/__tests__/rsc.test.tsx
+++ b/__tests__/rsc.test.tsx
@@ -1,0 +1,18 @@
+import { compileMDX } from '../rsc'
+
+describe('compileMDX', () => {
+  test('frontmatter types', async () => {
+    const { frontmatter } = await compileMDX<{ title: string }>({
+      source: `---
+title: 'Hello World'
+---
+
+# Hi`,
+    })
+
+    expect(frontmatter?.title).toEqual('Hello World')
+
+    // @ts-expect-error -- blah does not exist on the frontmatter type
+    expect(frontmatter?.blah).toBeUndefined()
+  })
+})

--- a/src/rsc.tsx
+++ b/src/rsc.tsx
@@ -27,12 +27,15 @@ export type MDXRemoteProps = Omit<
 
 export { MDXRemoteSerializeResult }
 
-export async function compileMDX({
+export async function compileMDX<TFrontmatter = Record<string, unknown>>({
   source,
   options,
   components = {},
 }: MDXRemoteProps) {
-  const { compiledSource, frontmatter, scope } = await serialize(
+  const { compiledSource, frontmatter, scope } = await serialize<
+    Record<string, unknown>,
+    TFrontmatter
+  >(
     source,
     options,
     // Enable RSC importSource

--- a/src/rsc.tsx
+++ b/src/rsc.tsx
@@ -10,10 +10,7 @@ import { VFileCompatible } from 'vfile'
 import { MDXProvider } from '@mdx-js/react'
 import { serialize } from './serialize'
 
-export type MDXRemoteProps = Omit<
-  MDXRemoteSerializeResult,
-  'compiledSource'
-> & {
+export type MDXRemoteProps = {
   source: VFileCompatible
   options?: SerializeOptions
   /**
@@ -27,11 +24,16 @@ export type MDXRemoteProps = Omit<
 
 export { MDXRemoteSerializeResult }
 
+export type CompileMDXResult<TFrontmatter = Record<string, unknown>> = {
+  content: React.ReactElement
+  frontmatter: TFrontmatter
+}
+
 export async function compileMDX<TFrontmatter = Record<string, unknown>>({
   source,
   options,
   components = {},
-}: MDXRemoteProps) {
+}: MDXRemoteProps): Promise<CompileMDXResult<TFrontmatter>> {
   const { compiledSource, frontmatter, scope } = await serialize<
     Record<string, unknown>,
     TFrontmatter

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -38,7 +38,10 @@ function getCompileOptions(
 /**
  * Parses and compiles the provided MDX string. Returns a result which can be passed into <MDXRemote /> to be rendered.
  */
-export async function serialize(
+export async function serialize<
+  TScope = Record<string, unknown>,
+  TFrontmatter = Record<string, unknown>
+>(
   source: VFileCompatible,
   {
     scope = {},
@@ -46,7 +49,7 @@ export async function serialize(
     parseFrontmatter = false,
   }: SerializeOptions = {},
   rsc: boolean = false
-): Promise<MDXRemoteSerializeResult> {
+): Promise<MDXRemoteSerializeResult<TScope, TFrontmatter>> {
   const vfile = new VFile(source)
 
   // makes frontmatter available via vfile.data.matter
@@ -66,8 +69,7 @@ export async function serialize(
 
   return {
     compiledSource,
-    frontmatter:
-      (vfile.data.matter as Record<string, string> | undefined) ?? {},
-    scope,
+    frontmatter: (vfile.data.matter ?? {}) as TFrontmatter,
+    scope: scope as TScope,
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,9 +39,9 @@ export type MDXRemoteSerializeResult<
    * For example, in cases where you want to provide template variables to the MDX, like `my name is {name}`,
    * you could provide scope as `{ name: "Some name" }`.
    */
-  scope?: TScope
+  scope: TScope
   /**
    * If parseFrontmatter was set to true, contains any parsed frontmatter found in the MDX source.
    */
-  frontmatter?: TFrontmatter
+  frontmatter: TFrontmatter
 }


### PR DESCRIPTION
Update `serialize()` and `compileMDX()` to accept generics for `scope` and `frontmatter`. Pass through the generic to ensure that the return types reflect the provided frontmatter types.

`serialize`:
```ts
import { serialize } from 'next-mdx-remote/serialize'

interface Frontmatter {
  title: string
  published: string
  description?: string
}

//     👇 should have type Frontmatter
const { frontmatter } = serialize<Record<string, unknown>, Frontmatter>(source)
```

`compileMDX`:
```tsx
import { compileMDX } from 'next-mdx-remote/rsc'

interface Frontmatter {
  title: string
  published: string
  description?: string
}

export default async function Page({ source }) {
	//              👇 should have type Frontmatter
	const { content, frontmatter } = await compileMDX<Frontmatter>(source)

	return (
		<>
			<h1>{frontmatter.title}</h1>
			{content}
		</>
	)
}