### PR TITLE
remove newline from template literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,8 +445,7 @@ import { MDXRemote } from 'next-mdx-remote/rsc'
 export default function Home() {
   return (
     <MDXRemote
-      source={`
-      # Hello World
+      source={`# Hello World
 
       This is from Server Components!
       `}
@@ -468,8 +467,7 @@ export default function Home() {
     // In Next.js you can also use `loading.js` for this.
     <Suspense fallback={<>Loading...</>}>
       <MDXRemote
-        source={`
-        # Hello World
+        source={`# Hello World
 
         This is from Server Components!
         `}
@@ -511,8 +509,7 @@ export default function Home() {
   return (
     <CustomMDX
       // h1 now renders with `large-text` className
-      source={`
-      # Hello World
+      source={`# Hello World
       This is from Server Components!
     `}
     />
@@ -524,25 +521,24 @@ export default function Home() {
 
 ```tsx
 // app/page.js
-import { compileMDX } from "next-mdx-remote/rsc";
+import { compileMDX } from 'next-mdx-remote/rsc'
 
 export default async function Home() {
-  const {content, frontmatter} = compileMDX({
-     source: `
-      ---
+  const { content, frontmatter } = compileMDX({
+    source: `---
       title: RSC Frontmatter Example
       ---
       # Hello World
       This is from Server Components!
     `,
-    options: { parseFrontmatter: true }
+    options: { parseFrontmatter: true },
   })
   return (
     <>
       <h1>{frontmatter.title}</h1>
       {content}
-   </>
-  );
+    </>
+  )
 }
 ```
 


### PR DESCRIPTION
fixes #345

I removed the newline from the template literal used to demonstrate the new rsc example with frontmatter to fix frontmatter not getting parsed, so now it is the same as the example that is given in the [advanced example](https://github.com/hashicorp/next-mdx-remote#additional-examples) "Parsing Frontmatter"

I also removed the newline from all the other examples, because if someone uses one of those and then adds frontmatter to his code he will end having the problem, so to avoid that I thought it is better to just change them all, but maybe this is not what you want in which case I can change it or you undo it