### PR TITLE
Allow async components in `next-mdx-remote/rsc`

### DIFF
--- a/__tests__/fixtures/rsc/app/app-dir-mdx/compile-mdx/page.js
+++ b/__tests__/fixtures/rsc/app/app-dir-mdx/compile-mdx/page.js
@@ -12,6 +12,7 @@ import { compileMDX } from 'next-mdx-remote/rsc'
 const MDX_COMPONENTS = {
   Test,
   strong: (props) => <strong className="custom-strong" {...props} />,
+  h1: async (props) => <h1 {...props} />,
   Dynamic: dynamic(() => import('../../../components/dynamic')),
 }
 

--- a/__tests__/fixtures/rsc/app/app-dir-mdx/mdxremote/page.js
+++ b/__tests__/fixtures/rsc/app/app-dir-mdx/mdxremote/page.js
@@ -12,6 +12,7 @@ import { MDXRemote } from 'next-mdx-remote/rsc'
 const MDX_COMPONENTS = {
   Test,
   strong: (props) => <strong className="custom-strong" {...props} />,
+  h1: async (props) => <h1 {...props} />,
   Dynamic: dynamic(() => import('../../../components/dynamic')),
 }
 

--- a/__tests__/rsc.test.tsx
+++ b/__tests__/rsc.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { compileMDX } from '../rsc'
 
 describe('compileMDX', () => {
@@ -17,5 +18,18 @@ title: 'Hello World'
 
     // @ts-expect-error -- blah does not exist on the frontmatter type
     expect(frontmatter.blah).toBeUndefined()
+  })
+
+  test('types should accept async components', async () => {
+    await compileMDX({
+      source: `---
+title: 'Hello World'
+---
+
+# Hi`,
+      components: {
+        h1: async (props) => <h1 {...props} />,
+      },
+    })
   })
 })


### PR DESCRIPTION
Async components are allowed in React Server Components, but currently if I pass an async component to the `components` prop, I get a type error. If I override the error with `ts-ignore` or `ts-expect-error` for example, it will work normally. So I have to fake the type like this for TypeScript to be happy.

```ts
async function _PostTitle({ id }: { id: string }) {
  const title = await getTitle(id);
  return <h1>{title}</h1>;
}
export const PostTitle = _PostTitle as unknown as React.FC<{ id: string }>;
```

This PR aims to change the types for `next-mdx-remote/rsc` only, so that async components are also accepted.