### PR TITLE
feat: support `export` statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ examples/*/package-lock.json
 examples/*/.next
 dist/
 *.tgz
+.idea/

--- a/__tests__/serialize.test.tsx
+++ b/__tests__/serialize.test.tsx
@@ -177,6 +177,24 @@ hello: world
     expect(result).toMatchInlineSnapshot(`"<h1>Hello world</h1>"`)
   })
 
+  test('should works with `export` statement', async () => {
+    const result = await renderStatic(
+      `export const num = 1
+
+export let str = 'foo'
+
+export var bool = true && 'true'
+
+export function Component() {
+  return 'from component'
+}
+
+# {num} {str} {bool} <Component />`
+    )
+
+    expect(result).toMatchInlineSnapshot(`"<h1>1 foo true from component</h1>"`)
+  })
+
   test('prints helpful message from compile error', async () => {
     try {
       await serialize(`This is very bad <GITHUB_USER>`)

--- a/src/plugins/remove-imports-exports.ts
+++ b/src/plugins/remove-imports-exports.ts
@@ -10,5 +10,11 @@ import { Plugin } from 'unified'
  * remark plugin which removes all import and export statements
  */
 export function removeImportsExportsPlugin(): Plugin {
-  return (tree) => remove(tree, 'mdxjsEsm')
+  return (ast) =>
+    remove(
+      ast,
+      (node) =>
+        node.type === 'mdxjsEsm' &&
+        node.data.estree.body[0].type === 'ImportDeclaration'
+    )
 }


### PR DESCRIPTION
tiny fix that add support of local `export` statements https://github.com/hashicorp/next-mdx-remote/issues/119