### PR TITLE
fix: watch for the correct log message

### DIFF
--- a/.jest/utils.tsx
+++ b/.jest/utils.tsx
@@ -135,7 +135,7 @@ export async function startDevServer(dir: string) {
         const msg = chunk.toString()
         process.stdout.write(chunk)
 
-        if (msg.includes('started server on') && msg.includes('url:')) {
+        if (msg.includes('Ready in')) {
           resolve(undefined)
         }
       })


### PR DESCRIPTION
This PR updates the expected "ready" message in `startDevServer` to reflect the new output used by Next.js v13.5.6, which gets CI green again.