### PR TITLE
fix: add extension to type imports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-export * from './dist/index'
+export * from './dist/index.js'

--- a/rsc.d.ts
+++ b/rsc.d.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-export * from './dist/rsc'
+export * from './dist/rsc.js'

--- a/serialize.d.ts
+++ b/serialize.d.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-export * from './dist/serialize'
+export * from './dist/serialize.js'


### PR DESCRIPTION
This PR adds explicit file extensions to the type imports for the root-level files.

Fixes #329