### PR TITLE
feat: restore useDynamicImport

### DIFF
--- a/__tests__/rsc.test.tsx
+++ b/__tests__/rsc.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { compileMDX } from '../rsc'
+import { compileMDX } from '../src/rsc'
 
 import { describe, test, expect } from 'vitest'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.4.1",
       "license": "MPL-2.0",
       "dependencies": {
+        "@babel/code-frame": "^7.23.5",
         "@mdx-js/mdx": "^3.0.1",
         "@mdx-js/react": "^3.0.1",
         "unist-util-remove": "^3.1.0",
@@ -16,7 +17,6 @@
         "vfile-matter": "^5.0.0"
       },
       "devDependencies": {
-        "@babel/code-frame": "^7.23.5",
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.1",
         "@hashicorp/remark-plugins": "^3.2.1",
@@ -68,7 +68,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.23.4",
@@ -286,7 +285,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.22.20",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -316,7 +314,6 @@
     },
     "node_modules/@babel/highlight": {
       "version": "7.23.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -1835,7 +1832,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -2278,7 +2274,6 @@
     },
     "node_modules/chalk": {
       "version": "2.4.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -2491,7 +2486,6 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -2499,7 +2493,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
@@ -3182,7 +3175,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -4003,7 +3995,6 @@
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8808,7 +8799,6 @@
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -17,11 +17,12 @@ function getCompileOptions(
   mdxOptions: SerializeOptions['mdxOptions'] = {},
   rsc: boolean = false
 ): CompileOptions {
+  const areImportsEnabled = mdxOptions.useDynamicImport ?? false
   // don't modify the original object when adding our own plugin
   // this allows code to reuse the same options object
   const remarkPlugins = [
     ...(mdxOptions.remarkPlugins || []),
-    removeImportsExportsPlugin,
+    ...(areImportsEnabled ? [] : [removeImportsExportsPlugin]),
   ]
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,9 @@ export interface SerializeOptions {
    * These options are passed to the MDX compiler.
    * See [the MDX docs.](https://github.com/mdx-js/mdx/blob/master/packages/mdx/index.js).
    */
-  mdxOptions?: Omit<CompileOptions, 'outputFormat' | 'providerImportSource'>
+  mdxOptions?: Omit<CompileOptions, 'outputFormat' | 'providerImportSource'> & {
+    useDynamicImport?: boolean
+  }
   /**
    * Indicate whether or not frontmatter should be parsed out of the MDX. Defaults to false
    */


### PR DESCRIPTION
This PR restores the option `useDynamicImport`, which allows users to opt-in to having `import`/`export` statements retained in the emitted MDX.

> [!CAUTION]
> This feature likely doesn't work as intended, and is being added to `v5` solely to retain API compatibility with `v4`. If your code relies on using `useDynamicImport` please leave a comment so we can better understand your use case.